### PR TITLE
Expose keepalive packets

### DIFF
--- a/k.lua
+++ b/k.lua
@@ -175,7 +175,7 @@ local wsEventNameLookup = {
   ownNames = "name",
   ownWebhooks = "webhook",
   motd = "motd",
-  keepalive = "keepalive",
+  keepalive = "keepalive"
 }
 
 local wsEvents = {}

--- a/k.lua
+++ b/k.lua
@@ -174,7 +174,8 @@ local wsEventNameLookup = {
   names = "name",
   ownNames = "name",
   ownWebhooks = "webhook",
-  motd = "motd"
+  motd = "motd",
+  keepalive = "keepalive",
 }
 
 local wsEvents = {}


### PR DESCRIPTION
Make it able to subscribe to keepalive packets, so you can use it to flash a lamp and indicate the health of the websocket, rather than with a timer.